### PR TITLE
chore: consolidate pre-commit repos into single list

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,16 +25,15 @@ repos:
       - id: trailing-whitespace
       - id: check-case-conflict
       - id: mixed-line-ending
-      - id: end-of-file-fixer
-      - id: check-case-conflict
       - id: forbid-new-submodules
       - id: pretty-format-json
         args: [ "--autofix", "--no-sort-keys", "--indent=4" ]
-
-repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.9.7
     hooks:
+      - id: ruff-format
+        name: ruff format code
+        files: ^(braindecode|docs|examples)/
       - id: ruff
         name: ruff lint docs & examples
         args:
@@ -63,10 +62,6 @@ repos:
             "--ignore=D103,D400,E402,D100,D101,D102,D105,D107,D415,D417,D205",    # drop these specific checks
           ]
         files: ^(docs|examples)/
-      - id: ruff-format
-        name: ruff format code
-        files: ^(braindecode|docs|examples)/
-
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
@@ -98,7 +93,7 @@ repos:
         verbose: true
 
   - repo: https://github.com/PyCQA/isort
-    rev: 6.0.1           
+    rev: 6.0.1
     hooks:
       - id: isort
         exclude: ^\.gitignore


### PR DESCRIPTION
## Summary
- merge pre-commit repositories into one `repos` list
- run formatting hooks before linting by placing `pre-commit-hooks` first

## Testing
- `pre-commit run --files .pre-commit-config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68991aec3e1c832094475bfd89e71363