### PR TITLE
CI: fix coverage upload condition

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
       run: pytest --cov=braindecode test/ --cov-report term --cov-report xml:coverage.xml
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v4
-      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'}}
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'}}
       with:
         fail_ci_if_error: true
         file: ./coverage.xml


### PR DESCRIPTION
## Summary
- run coverage upload job on a Python version present in the test matrix

## Testing
- `pre-commit run --files .github/workflows/tests.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68991af007c88320a86a205297d3f3a5

## Summary by Sourcery

CI:
- Trigger coverage upload on Python 3.10 instead of 3.9 in the CI workflow