### PR TITLE
Modernize homepage feature highlights

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -234,6 +234,196 @@ button.copybtn {
 img.hidden {
     visibility: hidden;
 }
+.feature-grid {
+    margin-bottom: 1.5rem;
+}
+.feature-anchor-nav {
+    font-weight: 700;
+    letter-spacing: 0.01em;
+}
+.feature-anchor-nav a {
+    color: var(--pst-color-text, #111827);
+}
+.feature-anchor-nav a:hover {
+    text-decoration: none;
+    color: rgb(var(--pst-color-link));
+}
+.lead-intro {
+    max-width: 960px;
+    margin-left: auto;
+    margin-right: auto;
+}
+.feature-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+.feature-card .sd-card-body p:last-child {
+    margin-bottom: 0;
+}
+.feature-card__eyebrow {
+    text-transform: uppercase;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: var(--pst-color-text-muted, #6c757d);
+    font-size: 0.78rem;
+    margin-bottom: 0.05rem;
+}
+.feature-card__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+}
+.feature-card__meta .sd-badge {
+    font-weight: 700;
+}
+.feature-card--panel {
+    border: 1px solid var(--pst-color-border-rgba);
+    background: linear-gradient(180deg, rgba(69, 157, 185, 0.12), rgba(69, 157, 185, 0));
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+html[data-theme="dark"] .feature-card--panel {
+    background: linear-gradient(180deg, rgba(69, 157, 185, 0.25), rgba(69, 157, 185, 0.05));
+}
+.feature-card--panel:hover {
+    transform: translateY(-2px);
+    border-color: rgba(69, 157, 185, 0.5);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+}
+.feature-highlight-card {
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1.1rem 1.2rem 1.25rem;
+    border: 1px solid var(--pst-color-border-rgba);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.75));
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.08);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+html[data-theme="dark"] .feature-highlight-card {
+    background: linear-gradient(175deg, rgba(58, 103, 144, 0.5), rgba(24, 30, 39, 0.55));
+    box-shadow: 0 14px 34px rgba(0, 0, 0, 0.35);
+}
+.feature-highlight-card--glass {
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.8));
+    border: 1px solid rgba(255, 255, 255, 0.8);
+    backdrop-filter: blur(6px);
+}
+html[data-theme="dark"] .feature-highlight-card--glass {
+    background: linear-gradient(155deg, rgba(39, 53, 68, 0.9), rgba(18, 24, 31, 0.85));
+    border-color: rgba(255, 255, 255, 0.08);
+}
+.feature-highlight-card:hover {
+    transform: translateY(-3px);
+    border-color: rgba(69, 157, 185, 0.45);
+    box-shadow: 0 16px 38px rgba(0, 0, 0, 0.14);
+}
+.feature-highlight-card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 10% 20%, rgba(69, 157, 185, 0.18), transparent 35%),
+        radial-gradient(circle at 80% 15%, rgba(238, 144, 64, 0.24), transparent 35%);
+    pointer-events: none;
+    opacity: 0.8;
+}
+.feature-highlight-card__icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.4rem;
+    font-weight: 800;
+    color: #fff;
+    background: linear-gradient(135deg, rgb(69, 157, 185), rgb(238, 144, 64));
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.12);
+    z-index: 1;
+}
+.feature-highlight-card__title {
+    font-weight: 800;
+    font-size: 1.15rem;
+    margin: 0;
+    z-index: 1;
+}
+.feature-highlight-card__copy {
+    z-index: 1;
+    margin-bottom: 0.35rem;
+}
+.feature-highlight-card__links {
+    z-index: 1;
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+.feature-highlight-card__links .sd-badge {
+    background: rgba(255, 255, 255, 0.3);
+    color: inherit;
+    border: 1px solid rgba(255, 255, 255, 0.6);
+}
+html[data-theme="dark"] .feature-highlight-card__links .sd-badge {
+    background: rgba(0, 0, 0, 0.15);
+    border-color: rgba(255, 255, 255, 0.2);
+}
+.feature-section {
+    position: relative;
+    margin-top: 1.25rem;
+}
+.feature-section--hero {
+    margin-top: 0.5rem;
+}
+.feature-hero__panel {
+    position: relative;
+    padding: 1.15rem 1.2rem 1.35rem;
+    background: linear-gradient(120deg, rgba(69, 157, 185, 0.1), rgba(238, 144, 64, 0.14));
+    overflow: hidden;
+    border: 1px solid var(--pst-color-border-rgba);
+}
+html[data-theme="dark"] .feature-hero__panel {
+    background: linear-gradient(120deg, rgba(69, 157, 185, 0.2), rgba(238, 144, 64, 0.25));
+}
+.feature-hero__panel::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 16% 30%, rgba(255, 255, 255, 0.25), transparent 36%),
+        radial-gradient(circle at 85% 10%, rgba(255, 255, 255, 0.35), transparent 32%);
+    pointer-events: none;
+}
+.feature-section__title {
+    font-weight: 800;
+    letter-spacing: -0.02em;
+}
+.feature-section__subtitle {
+    max-width: 720px;
+    margin: 0 auto 1.15rem;
+    color: var(--pst-color-text-muted, #6c757d);
+}
+.feature-section__meta {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin: -0.35rem auto 0.85rem;
+}
+.feature-section__meta .sd-btn {
+    font-weight: 700;
+    border-radius: 999px;
+    padding-inline: 1.15rem;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+}
+.feature-section__meta .sd-btn-secondary {
+    border: 1px solid var(--pst-color-border-rgba);
+    background-color: var(--pst-color-surface, #fff);
+    color: var(--pst-color-text, #111827);
+}
+.feature-section__meta .sd-btn-secondary:hover {
+    background: var(--pst-color-background-rgba);
+}
 /*model grid*/
 /* For the horizontally scrolling model cards */
 .horizontal-scroll-container {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,17 +24,377 @@ Braindecode Homepage
    :class: logo mainlogo only-dark
    :align: center
 
-.. rst-class:: h4 text-center font-weight-light my-4
+.. rst-class:: h4 text-center font-weight-light my-4 lead-intro
 
    Braindecode is an open-source Python toolbox for decoding raw electrophysiological brain
    data with deep learning models. It includes dataset fetchers, data preprocessing and
    visualization tools, as well as implementations of several deep learning
    architectures and data augmentations for analysis of EEG, ECoG and MEG.
 
-.. rst-class:: h4 text-center font-weight-light my-4
+.. rst-class:: h4 text-center font-weight-light my-4 lead-intro
 
    For neuroscientists who want to work with deep learning and
    deep learning researchers who want to work with neurophysiological data.
+
+.. rst-class:: feature-anchor-nav text-center my-4
+
+   `Models <#models-grid>`_ · `Datasets <#datasets-area>`_ · `Preprocessing <#preprocessing-tools>`_ · `Tutorials <#tutorials-ribbon>`_
+
+.. _feature-highlights:
+
+.. rst-class:: feature-section feature-section--hero
+
+   .. container:: feature-hero__panel sd-shadow-sm sd-rounded-3
+
+      .. grid:: 1 2 4
+         :gutter: 1.2
+         :class-container: feature-grid
+
+         .. grid-item-card::
+            :link: #models-grid
+            :class-card: sd-card sd-rounded-3 h-100 feature-highlight-card feature-highlight-card--glass
+
+            .. rst-class:: feature-highlight-card__icon
+
+               ▤
+
+            .. rst-class:: feature-highlight-card__title
+
+               Models, ready to fine-tune
+
+            .. rst-class:: feature-highlight-card__copy
+
+               Curated architectures for motor imagery, sleep staging, and cross-dataset transfer—direct from the models gallery.
+
+            .. rst-class:: feature-highlight-card__links
+
+               :badge:`Deep4 <primary>` :badge:`EEGNet v4 <secondary>` :badge:`ShallowFBCSPNet <primary>`
+
+         .. grid-item-card::
+            :link: #datasets-area
+            :class-card: sd-card sd-rounded-3 h-100 feature-highlight-card feature-highlight-card--glass
+
+            .. rst-class:: feature-highlight-card__icon
+
+               ⧉
+
+            .. rst-class:: feature-highlight-card__title
+
+               Datasets with MOABB built-in
+
+            .. rst-class:: feature-highlight-card__copy
+
+               Benchmark-ready downloads, cached metadata, and dashboards to triage EEG, ECoG, and MEG experiments faster.
+
+            .. rst-class:: feature-highlight-card__links
+
+               :badge:`MOABB <primary>` :badge:`EEGDash <secondary>` :badge:`Builders <primary>`
+
+         .. grid-item-card::
+            :link: #preprocessing-tools
+            :class-card: sd-card sd-rounded-3 h-100 feature-highlight-card feature-highlight-card--glass
+
+            .. rst-class:: feature-highlight-card__icon
+
+               ⚙
+
+            .. rst-class:: feature-highlight-card__title
+
+               Preprocess with MNE-native steps
+
+            .. rst-class:: feature-highlight-card__copy
+
+               EEGPrep-style cleaning, notch and band-pass utilities, and window builders that keep Raw and Epochs metadata intact.
+
+            .. rst-class:: feature-highlight-card__links
+
+               :badge:`EEGPrep <primary>` :badge:`Filtering <secondary>` :badge:`Windowing <primary>`
+
+         .. grid-item-card::
+            :link: #tutorials-ribbon
+            :class-card: sd-card sd-rounded-3 h-100 feature-highlight-card feature-highlight-card--glass
+
+            .. rst-class:: feature-highlight-card__icon
+
+               ▶
+
+            .. rst-class:: feature-highlight-card__title
+
+               Tutorials that ship pipelines
+
+            .. rst-class:: feature-highlight-card__copy
+
+               Walk-throughs that combine datasets, preprocessing, augmentation, and training recipes you can copy-paste.
+
+            .. rst-class:: feature-highlight-card__links
+
+               :badge:`Motor imagery <primary>` :badge:`Sleep staging <secondary>` :badge:`Benchmarks <primary>`
+
+.. _models-grid:
+
+Models
+------
+
+.. rst-class:: feature-section__subtitle text-center
+
+   Browse ready-to-train architectures with capability badges and direct entry to the models gallery.
+
+.. rst-class:: feature-section__meta text-center
+
+   :btn-link-primary:`Open models gallery <models/models>` :btn-link-secondary:`See API <api.html#models>`
+
+.. grid:: 1 2 4
+   :gutter: 1.2
+   :class-container: feature-grid
+
+   .. grid-item-card:: Deep4
+      :link: models/models
+      :class-card: sd-card sd-shadow-sm sd-rounded-2 h-100 feature-card feature-card--panel
+
+      .. rst-class:: feature-card__eyebrow
+
+         Sensorimotor decoding
+
+      .. rst-class:: feature-card__meta
+
+         :badge:`BCI <primary>` :badge:`ConvNet <secondary>`
+
+      Proven baseline for motor imagery and mu/beta rhythms with interpretable spatial filters and strong MOABB baselines.
+
+   .. grid-item-card:: ShallowFBCSPNet
+      :link: models/models
+      :class-card: sd-card sd-shadow-sm sd-rounded-2 h-100 feature-card feature-card--panel
+
+      .. rst-class:: feature-card__eyebrow
+
+         Filter-bank precision
+
+      .. rst-class:: feature-card__meta
+
+         :badge:`Bandpower <primary>` :badge:`Lightweight <secondary>`
+
+      Filter-bank design optimized for lightning-fast benchmarking, latency-sensitive feedback, and spectral interpretability.
+
+   .. grid-item-card:: EEGNet v4
+      :link: models/models
+      :class-card: sd-card sd-shadow-sm sd-rounded-2 h-100 feature-card feature-card--panel
+
+      .. rst-class:: feature-card__eyebrow
+
+         Portable efficiency
+
+      .. rst-class:: feature-card__meta
+
+         :badge:`Compact <primary>` :badge:`Transfer learning <secondary>`
+
+      Depthwise-separable convolutions built for cross-dataset transfer, on-device inference, and rapid prototyping.
+
+   .. grid-item-card:: Sleep Stager (U-Time)
+      :link: models/models
+      :class-card: sd-card sd-shadow-sm sd-rounded-2 h-100 feature-card feature-card--panel
+
+      .. rst-class:: feature-card__eyebrow
+
+         Clinical context
+
+      .. rst-class:: feature-card__meta
+
+         :badge:`Sleep <primary>` :badge:`Sequence aware <secondary>`
+
+      Temporal context modeling tuned for overnight recordings, hypnogram export, and clinical-grade sleep-stage scoring.
+
+.. _datasets-area:
+
+Datasets
+--------
+
+.. rst-class:: feature-section__subtitle text-center
+
+   Pull curated EEG, ECoG, and MEG datasets with reproducible pipelines, dashboards, and cache-aware loaders.
+
+.. rst-class:: feature-section__meta text-center
+
+   :btn-link-primary:`MOABB integration <api.html#braindecode.datasets.MOABBDataset>` :btn-link-secondary:`EEGDash <https://neurotechx.github.io/eegdash/>`
+
+.. grid:: 1 2 3
+   :gutter: 1.2
+   :class-container: feature-grid
+
+   .. grid-item-card:: MOABB-first downloads
+      :link: api.html#braindecode.datasets.MOABBDataset
+      :class-card: sd-card sd-shadow-sm sd-rounded-2 h-100 feature-card feature-card--panel
+
+      .. rst-class:: feature-card__eyebrow
+
+         Benchmark pipelines
+
+      .. rst-class:: feature-card__meta
+
+         :badge:`Benchmark-ready <primary>` :badge:`Caching <secondary>`
+
+      Load 20+ paradigms through :class:`braindecode.datasets.MOABBDataset` with automatic caching, subject/session metadata, and reproducible MOABB splits.
+
+   .. grid-item-card:: EEGDash summaries
+      :link: https://neurotechx.github.io/eegdash/
+      :class-card: sd-card sd-shadow-sm sd-rounded-2 h-100 feature-card feature-card--panel
+
+      .. rst-class:: feature-card__eyebrow
+
+         Visual QA
+
+      .. rst-class:: feature-card__meta
+
+         :badge:`Visualization <primary>` :badge:`Quality checks <secondary>`
+
+      Explore dashboards of recordings, annotations, and channel health to triage datasets before committing compute.
+
+   .. grid-item-card:: Dataset builders
+      :link: api.html#dataset-builders-functions
+      :class-card: sd-card sd-shadow-sm sd-rounded-2 h-100 feature-card feature-card--panel
+
+      .. rst-class:: feature-card__eyebrow
+
+         Ready for training
+
+      .. rst-class:: feature-card__meta
+
+         :badge:`Raw to windows <primary>` :badge:`MNE-friendly <secondary>`
+
+      Turn Raw, Epochs, or NumPy arrays into :class:`braindecode.datasets.BaseConcatDataset` objects, preserving description metadata for downstream splits.
+
+.. _preprocessing-tools:
+
+Preprocessing
+-------------
+
+.. rst-class:: feature-section__subtitle text-center
+
+   Clean, window, and standardize with built-in pipelines powered by MNE utilities.
+
+.. rst-class:: feature-section__meta text-center
+
+   :btn-link-primary:`EEGPrep API <api.html#braindecode.preprocessing.EEGPrep>` :btn-link-secondary:`Signal processing <api.html#signal-processing>`
+
+.. grid:: 1 2 3
+   :gutter: 1.2
+   :class-container: feature-grid
+
+   .. grid-item-card:: EEGPrep pipeline
+      :link: api.html#braindecode.preprocessing.EEGPrep
+      :class-card: sd-card sd-shadow-sm sd-rounded-2 h-100 feature-card feature-card--panel
+
+      .. rst-class:: feature-card__eyebrow
+
+         Automated cleanup
+
+      .. rst-class:: feature-card__meta
+
+         :badge:`Artifact removal <primary>` :badge:`Automated <secondary>`
+
+      Run channel checks, detrending, burst and drift removal, re-referencing, and bad-channel interpolation with sensible defaults inspired by EEGPrep.
+
+   .. grid-item-card:: MNE-powered helpers
+      :link: api.html#signal-processing
+      :class-card: sd-card sd-shadow-sm sd-rounded-2 h-100 feature-card feature-card--panel
+
+      .. rst-class:: feature-card__eyebrow
+
+         Signal processing
+
+      .. rst-class:: feature-card__meta
+
+         :badge:`Filtering <primary>` :badge:`Hilbert <secondary>`
+
+      Apply :class:`~braindecode.preprocessing.Filter`, :class:`~braindecode.preprocessing.NotchFilter`, and analytic signals via :class:`~braindecode.preprocessing.ApplyHilbert` using familiar MNE primitives.
+
+   .. grid-item-card:: Windowing utilities
+      :link: api.html#core-functions
+      :class-card: sd-card sd-shadow-sm sd-rounded-2 h-100 feature-card feature-card--panel
+
+      .. rst-class:: feature-card__eyebrow
+
+         Ready-made splits
+
+      .. rst-class:: feature-card__meta
+
+         :badge:`Trials <primary>` :badge:`Continuous <secondary>`
+
+      Build trials with :func:`~braindecode.preprocessing.create_windows_from_events` or sliding segments with :func:`~braindecode.preprocessing.create_fixed_length_windows`, preserving metadata across windows.
+
+.. _tutorials-ribbon:
+
+Tutorials
+---------
+
+.. rst-class:: feature-section__subtitle text-center
+
+   Start from curated walkthroughs that combine datasets, preprocessing, and training recipes.
+
+.. rst-class:: feature-section__meta text-center
+
+   :btn-link-primary:`View all tutorials <auto_examples/index.html>` :btn-link-secondary:`Install & setup <install/install.html>`
+
+.. rst-class:: horizontal-scroll-container
+
+   .. grid:: 1 2 4
+      :gutter: 1.2
+      :class-container: feature-grid
+
+      .. grid-item-card:: BCIC IV 2a (trialwise)
+         :link: auto_examples/model_building/plot_bcic_iv_2a_moabb_trial.html
+         :class-card: sd-card sd-shadow-sm sd-rounded-2 h-100 feature-card feature-card--panel
+
+         .. rst-class:: feature-card__eyebrow
+
+            Motor imagery
+
+         .. rst-class:: feature-card__meta
+
+            :badge:`MOABB <primary>` :badge:`Deep4 <secondary>`
+
+         Fetch, window, and train on motor imagery with reproducible metrics.
+
+      .. grid-item-card:: Sleep staging with U-Time
+         :link: auto_examples/applied_examples/plot_sleep_staging_usleep.html
+         :class-card: sd-card sd-shadow-sm sd-rounded-2 h-100 feature-card feature-card--panel
+
+         .. rst-class:: feature-card__eyebrow
+
+            Overnight EEG
+
+         .. rst-class:: feature-card__meta
+
+            :badge:`Sleep <primary>` :badge:`Sequence <secondary>`
+
+         Learn temporal context models and export predictions for hypnogram review.
+
+      .. grid-item-card:: Lightning vs. pure PyTorch
+         :link: auto_examples/model_building/plot_train_in_pure_pytorch_and_pytorch_lightning.html
+         :class-card: sd-card sd-shadow-sm sd-rounded-2 h-100 feature-card feature-card--panel
+
+         .. rst-class:: feature-card__eyebrow
+
+            Training stacks
+
+         .. rst-class:: feature-card__meta
+
+            :badge:`Training loops <primary>` :badge:`Callbacks <secondary>`
+
+         Compare minimal training scripts with richer logging and checkpointing workflows.
+
+      .. grid-item-card:: MOABB benchmarks at scale
+         :link: auto_examples/advanced_training/plot_moabb_benchmark.html
+         :class-card: sd-card sd-shadow-sm sd-rounded-2 h-100 feature-card feature-card--panel
+
+         .. rst-class:: feature-card__eyebrow
+
+            Reproducible suites
+
+         .. rst-class:: feature-card__meta
+
+            :badge:`Benchmark <primary>` :badge:`Cross-session <secondary>`
+
+         Run large suites with consistent preprocessing to stress-test model robustness.
 
 .. frontpage gallery is added by a conditional in _templates/layout.html
 


### PR DESCRIPTION
## Summary
- refresh the homepage hero cards with glassy panels, navigation pills, and section call-to-actions
- add quick action buttons for models, datasets, preprocessing, and tutorials anchored to their sections
- extend styling for anchor nav, hero panel, glass cards, and CTA buttons to match the modern layout

## Testing
- pre-commit run --all-files

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925bfb5be988320816baf89f61f0ccf)

## Summary by Sourcery

Refresh the homepage feature sections with modern highlight cards and hero panel styling.

Enhancements:
- Introduce new CSS styles for feature grids, hero panels, and glass highlight cards to modernize the homepage layout and interactions.
- Add styling for anchor navigation, section metadata, and call-to-action buttons to improve scannability and quick access to key documentation areas.